### PR TITLE
[Refactor, Rename] : workBook entity isShared 필드 삭제

### DIFF
--- a/src/main/java/com/example/stepbackend/aggregate/dto/workbook/ReadWorkBookDTO.java
+++ b/src/main/java/com/example/stepbackend/aggregate/dto/workbook/ReadWorkBookDTO.java
@@ -51,7 +51,6 @@ public class ReadWorkBookDTO {
         return ReadWorkBookDTO.builder()
                 .workBookNo(workBook.getWorkBookNo())
                 .questionNos(workBook.getQuestionNos().split(", "))
-                .isShared(workBook.getIsShared())
                 .questionTypes(questionTypes)
                 .questionName(workBook.getWorkBookName())
                 .lastUpdatedTime(formattedLastUpdatedTime)

--- a/src/main/java/com/example/stepbackend/aggregate/entity/Board.java
+++ b/src/main/java/com/example/stepbackend/aggregate/entity/Board.java
@@ -1,0 +1,47 @@
+package com.example.stepbackend.aggregate.entity;
+
+import lombok.*;
+import org.hibernate.annotations.Comment;
+
+import javax.persistence.*;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+
+@Entity
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table
+public class Board {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column
+    @Comment("게시글 번호")
+    private Long boardNo;
+
+    @Column
+    @Comment("게시글명")
+    private String boardName;
+
+    @Column
+    @Comment("회원 번호")
+    private Long memberNo;
+
+    @Column
+    @Comment("나만의 문제로 만든 문제 번호들")
+    private String questionNos;
+
+    @Column
+    @Comment("나만의 문제에 존재하는 문제 타입들")
+    private String questionTypes;
+
+    @Column
+    @Comment("문제집 설명")
+    private String description;
+
+    @Column
+    @Comment("만들어진 날짜")
+    private LocalDate createdAt;
+}

--- a/src/main/java/com/example/stepbackend/aggregate/entity/WorkBook.java
+++ b/src/main/java/com/example/stepbackend/aggregate/entity/WorkBook.java
@@ -36,10 +36,6 @@ public class WorkBook {
     private String questionNos;
 
     @Column
-    @Comment("공유 여부")
-    private Boolean isShared;
-
-    @Column
     @Comment("나만의 문제에 존재하는 문제 타입들")
     private String questionTypes;
 
@@ -65,14 +61,9 @@ public class WorkBook {
                 .memberNo(memberNo)
                 .questionNos(questionNosToString)
                 .workBookName(createWorkBookRequestDTO.getWorkBookName())
-                .isShared(false)
                 .questionTypes(questionTypesToString)
                 .lastUpdatedTime(LocalDateTime.now())
                 .build();
-    }
-
-    public void updateIsShared(Boolean isShared) {
-        this.isShared = isShared;
     }
 
     public void updateWorkBookName(String workBookName, String description) {

--- a/src/main/java/com/example/stepbackend/repository/BoardRepository.java
+++ b/src/main/java/com/example/stepbackend/repository/BoardRepository.java
@@ -1,0 +1,9 @@
+package com.example.stepbackend.repository;
+
+import com.example.stepbackend.aggregate.entity.Board;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface BoardRepository extends JpaRepository<Board, Long> {
+}

--- a/src/main/java/com/example/stepbackend/service/BoardService.java
+++ b/src/main/java/com/example/stepbackend/service/BoardService.java
@@ -1,0 +1,10 @@
+package com.example.stepbackend.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class BoardService {
+
+}

--- a/src/main/java/com/example/stepbackend/service/WorkbookService.java
+++ b/src/main/java/com/example/stepbackend/service/WorkbookService.java
@@ -34,13 +34,6 @@ public class WorkbookService {
         return createWorkBookDTO;
     }
 
-    /* 문제집 공유 여부 설정 */
-    @Transactional
-    public void isSharedWorkBook(Long memberNo, Long workBookNo, Boolean isShared) {
-        WorkBook workBook = workBookRepository.findByMemberNoAndWorkBookNo(memberNo, workBookNo);
-        workBook.updateIsShared(isShared);
-    }
-
     /* 마이 페이지 내 문제집 전체 보기*/
     @Transactional(readOnly = true)
     public Page<ReadWorkBookDTO> getWorkBookMyPage(Long memberNo, Pageable pageable) {

--- a/src/test/java/com/example/stepbackend/service/BoardServiceTest.java
+++ b/src/test/java/com/example/stepbackend/service/BoardServiceTest.java
@@ -1,0 +1,27 @@
+package com.example.stepbackend.service;
+
+import com.example.stepbackend.repository.BoardRepository;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class BoardServiceTest {
+    @Autowired
+    private BoardService boardService;
+
+    @Autowired
+    private BoardRepository boardRepository;
+
+    @DisplayName("나만의 문제집 공유")
+    @Test
+    void createMyWorkBook(){
+        
+    }
+
+}

--- a/src/test/java/com/example/stepbackend/service/WorkbookServiceTest.java
+++ b/src/test/java/com/example/stepbackend/service/WorkbookServiceTest.java
@@ -58,40 +58,6 @@ class WorkbookServiceTest {
     }
 
 
-    @DisplayName("나만의 문제집 공유 설정")
-    @ParameterizedTest
-    @ValueSource(booleans = {false, true})
-    void isSharedWorkBook(boolean settings){
-        // given
-        Long memberNo = 1L;
-
-        List<Long> questionNos = Arrays.asList(1L,2L,3L);
-        List<String> questionTypes = Arrays.asList("blank", "title");
-        String workBookName = "미미스크립트";
-
-        CreateWorkBookRequestDTO createWorkBookRequestDTO = CreateWorkBookRequestDTO.builder()
-                .workBookName(workBookName)
-                .questionNos(questionNos)
-                .build();
-
-        WorkBook workBook = WorkBook.toEntity(memberNo, createWorkBookRequestDTO, questionTypes);
-
-        WorkBook foundWorkbook =  workBookRepository.save(workBook);
-
-        Boolean isShared = settings;
-
-        // when
-        workbookService.isSharedWorkBook(memberNo, foundWorkbook.getWorkBookNo(), isShared);
-
-        // then
-        if(isShared){
-            Assertions.assertTrue(workBookRepository.findByMemberNoAndWorkBookNo(memberNo, foundWorkbook.getWorkBookNo()).getIsShared());
-        }else{
-            Assertions.assertFalse(workBookRepository.findByMemberNoAndWorkBookNo(memberNo, foundWorkbook.getWorkBookNo()).getIsShared());
-        }
-    }
-
-
     @DisplayName("나만의 문제집 마이 페이지 조회")
     @Test
     void getWorkBook(){


### PR DESCRIPTION
## 연관 이슈
이슈 번호 : #67 

## 해당 PR은 어떤 유형의 pr인가요?

- [ ] Bugfix
- [ ] Feature
- [x] Rename
- [ ] Test
- [x] Refactoring
- [ ] Documentation content changes
- [ ] Other... Please describe:


## 해당 기능에 대해 간략하게 설명해주세요
- 기존에는 스크랩처럼 체크박스 형태로 체크 표시 후 공유 버튼을 누르면 isShared가 true 바뀌고 자랑 게시판에 isShared가 true 값만 가져오는 형식으로 할 예정이었습니다.
- 하지만 해당 방식을 진행하면 다음과 같은 애로사항이 발생합니다.
  - 나의 문제집 페이지 내 `수정` 버튼을 통해 기능을 수행하면 문제집 제목과 설명을 바꿀 수 있습니다.
  - 기존의 방식대로 갈 경우 `수정` 버튼을 통해 자랑 게시판에 등록된 문제집이 나의 문제집 페이지에서 수정될 수 있습니다.
  - 추구하고자 한 방향은 **나의 문제집**에 존재하는 문제집과 **문제집 자랑**에 존재하는 문제집이 같은 내용을 갖더라도 다른 객체가 되는 것이었습니다.
  - 그래서 공유하기 버튼을 추가함으로써, 문제집 자랑 게시판에 올리는 문제집의 유일성과 무결성을 보장하고자 하였습니다.
  

## 해당 기능은 중대한 변경사항이 있나요?
<!--  API 변경, 구조 변경, 중요한 기능의 제거 또는 변경일 경우 "Yes", 다른 기능에 영향을 주지 않는 기능 추가와 버그 수정일 경우 "no" -->
- [x] Yes
- [ ] No


## 참고사항
<!-- pr 결과를 찍은 사진이나 참고할만한 사항같은 것을 적어주세요 -->

### before (isShared 존재)
<img width="819" alt="image" src="https://github.com/Convergence-Project/step-backend/assets/105257665/b4491255-5494-488f-bb72-23fa44697750">


## After (IsShared 삭제)
<img width="854" alt="image" src="https://github.com/Convergence-Project/step-backend/assets/105257665/95233659-1e97-4f06-b550-dd4cb29f1c76">

